### PR TITLE
downgrade kubectl to 1.9 to be compatible with 1.8 server version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ FROM openjdk:8u171
 # Environment variables
 ENV SCALA_VERSION=2.12.7
 ENV SBT_VERSION=1.2.3
-ENV KUBECTL_VERSION=v1.10.4
+ENV KUBECTL_VERSION=v1.9.11
 ENV HOME=/config
 
 # Scala expects this file


### PR DESCRIPTION
kubectl 1.10.4 is not fully compatible with k8s 1.8.7. 
The kubeconfig used in circle-ci is using a server certificate instead of a token, which make trouble scaling a deployment using version 1.10.

Switching to latest 1.9.X as tests have succeeded using that version. 