### PR TITLE
Update versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,16 +6,13 @@
 # - Docker
 
 # Pull base image
-FROM openjdk:8u181
+FROM openjdk:8u222
 
 # Environment variables
-ENV SCALA_VERSION=2.12.8
+ENV SCALA_VERSION=2.12.9
 ENV SBT_VERSION=1.2.8
-ENV KUBECTL_VERSION=v1.12.5
+ENV KUBECTL_VERSION=v1.14.5
 ENV HOME=/config
-
-# Scala expects this file
-RUN touch /usr/lib/jvm/java-8-openjdk-amd64/release
 
 # Install Scala
 ## Piping curl directly in tar


### PR DESCRIPTION
Original purpose was to support Scala 2.12.9, but also bumped the other dependencies

openjdk: 8u181 -> 8u222
scala: 2.12.8 -> 2.12.9
kubectl: 1.12.5 -> 1.14.5