### PR TITLE
Refactor dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ ENV HOME=/config
 RUN \
   curl -fsL https://downloads.typesafe.com/scala/$SCALA_VERSION/scala-$SCALA_VERSION.tgz | tar xfz - -C /root/ && \
   echo >> /root/.bashrc && \
-  echo "export PATH=~/scala-$SCALA_VERSION/bin:$PATH" >> /root/.bashrc
+  echo "export PATH=/root/scala-$SCALA_VERSION/bin:$PATH" >> /root/.bashrc
 
 # Install sbt
 RUN \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@
 # - AWS CLI
 # - Docker
 
+
 # Pull base image
 FROM openjdk:8u222
 
@@ -16,10 +17,11 @@ ENV HOME=/config
 
 # Install Scala
 ## Piping curl directly in tar
+ENV PATH="/root/scala-$SCALA_VERSION/bin:${PATH}"
+SHELL ["/bin/bash", "-o", "pipefail", "-x", "-c"]
 RUN \
   curl -fsL https://downloads.typesafe.com/scala/$SCALA_VERSION/scala-$SCALA_VERSION.tgz | tar xfz - -C /root/ && \
-  echo >> /root/.bashrc && \
-  echo "export PATH=/root/scala-$SCALA_VERSION/bin:$PATH" >> /root/.bashrc
+  scala -version
 
 # Install sbt
 RUN \
@@ -27,39 +29,45 @@ RUN \
   dpkg -i sbt-$SBT_VERSION.deb && \
   rm sbt-$SBT_VERSION.deb && \
   apt-get update && \
-  apt-get install sbt && \
-  sbt sbtVersion
+  apt-get install -y --no-install-recommends sbt=${SBT_VERSION} && \
+  sbt sbtVersion && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/*
 
 # Install the AWS CLI
-# RUN set -x && \
-RUN apt-get install -y bash ca-certificates coreutils curl gawk git grep groff gzip jq less python sed tar zip && \
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      bash ca-certificates coreutils curl gawk git grep groff gzip jq less python sed tar zip && \
     curl -sSL https://s3.amazonaws.com/aws-cli/awscli-bundle.zip -o awscli-bundle.zip && \
-    unzip awscli-bundle.zip
-RUN ./awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws && \
+    unzip awscli-bundle.zip && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \
+    ./awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws && \
     rm awscli-bundle.zip && \
     rm -Rf awscli-bundle
 
 # Install kubectl
 # Note: Latest version may be found on:
 # https://aur.archlinux.org/packages/kubectl-bin/
-RUN set -x \
-  && curl -LO https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl \
-  && mv kubectl /usr/local/bin/kubectl \
-  && chmod +x /usr/local/bin/kubectl
+RUN \
+  curl -LO https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl && \
+  mv kubectl /usr/local/bin/kubectl && \
+  chmod +x /usr/local/bin/kubectl
 
-RUN set -x && \
-    chmod +x /usr/local/bin/kubectl && \
-    \
-    # Create non-root user (with a randomly chosen UID/GUI).
-    adduser kubectl -Du 2342 -h /config && \
-    kubectl version --client
+RUN \
+  chmod +x /usr/local/bin/kubectl && \
+  # Create non-root user (with a randomly chosen UID/GUI).
+  adduser kubectl -Du 2342 -h /config && \
+  kubectl version --client
 
 # Install Docker
-RUN set -x && \
-  apt-get install -y software-properties-common apt-transport-https  && \
-  curl -fsSL https://download.docker.com/linux/$(. /etc/os-release; echo "$ID")/gpg | apt-key add -  && \
-  add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/debian stretch stable"  && \
-  apt-get update && apt-get install -y docker-ce
+RUN \
+  apt-get update && apt-get install -y --no-install-recommends software-properties-common apt-transport-https && \
+  curl -fsSL https://download.docker.com/linux/$(. /etc/os-release; echo "$ID")/gpg | apt-key add - && \
+  add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/debian stretch stable" && \
+  apt-get update && \
+  apt-get install -y --no-install-recommends docker-ce && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/*
 
 # Define working directory
 WORKDIR /root


### PR DESCRIPTION
Should be merged after #6, I did not want to put this refactoring on top of the version bump...

- set pipefail and -x globally
- output the scala version after installation
- cleanup apt caches in every layer
- use sbt version in apt-get
- remove now redundant `RUN set -x`
- add `--no-install-recommends` to make the image smaller

Summary: works as before (as far as tested :D, and `scala` is correctly in PATH which was not the case before this pr) but received some love and is ~ 400 MB smaller :tada: 