### PR TITLE
Extract install step of tools and initialize sbt plus compiler-bridge

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,6 @@
 # - AWS CLI
 # - Docker
 
-
 # Pull base image
 FROM openjdk:8u222
 
@@ -15,10 +14,18 @@ ENV SBT_VERSION=1.2.8
 ENV KUBECTL_VERSION=v1.14.5
 ENV HOME=/config
 
+# Install some tools
+RUN \
+  apt-get update && apt-get install -y --no-install-recommends \
+    bash ca-certificates coreutils curl gawk git grep groff gzip \
+    jq less python sed tar zip software-properties-common apt-transport-https && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/* && \
+
 # Install Scala
 ## Piping curl directly in tar
 ENV PATH="/root/scala-$SCALA_VERSION/bin:${PATH}"
-SHELL ["/bin/bash", "-o", "pipefail", "-x", "-c"]
+SHELL ["/bin/bash", "-eo", "pipefail", "-x", "-c"]
 RUN \
   curl -fsL https://downloads.typesafe.com/scala/$SCALA_VERSION/scala-$SCALA_VERSION.tgz | tar xfz - -C /root/ && \
   scala -version
@@ -30,20 +37,21 @@ RUN \
   rm sbt-$SBT_VERSION.deb && \
   apt-get update && \
   apt-get install -y --no-install-recommends sbt=${SBT_VERSION} && \
-  sbt sbtVersion && \
+  export TEMP="$(mktemp -d)" && \
+  cd "${TEMP}" && \
+  echo "class Question { def answer = 42 }" > Question.scala && \
+  sbt "set scalaVersion := \"${SCALA_VERSION}\"" compile && \
+  rm -r "${TEMP}" && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*
 
 # Install the AWS CLI
-RUN apt-get update && apt-get install -y --no-install-recommends \
-      bash ca-certificates coreutils curl gawk git grep groff gzip jq less python sed tar zip && \
-    curl -sSL https://s3.amazonaws.com/aws-cli/awscli-bundle.zip -o awscli-bundle.zip && \
-    unzip awscli-bundle.zip && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/* && \
-    ./awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws && \
-    rm awscli-bundle.zip && \
-    rm -Rf awscli-bundle
+RUN \
+  curl -sSL https://s3.amazonaws.com/aws-cli/awscli-bundle.zip -o awscli-bundle.zip && \
+  unzip awscli-bundle.zip && \
+  ./awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws && \
+  rm awscli-bundle.zip && \
+  rm -Rf awscli-bundle
 
 # Install kubectl
 # Note: Latest version may be found on:
@@ -61,11 +69,9 @@ RUN \
 
 # Install Docker
 RUN \
-  apt-get update && apt-get install -y --no-install-recommends software-properties-common apt-transport-https && \
   curl -fsSL https://download.docker.com/linux/$(. /etc/os-release; echo "$ID")/gpg | apt-key add - && \
   add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/debian stretch stable" && \
-  apt-get update && \
-  apt-get install -y --no-install-recommends docker-ce && \
+  apt-get update && apt-get install -y --no-install-recommends docker-ce && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
On the first execution, sbt downloads some scala jars and on first
compile it also compiles the compiler-bridge:

```
[info] downloading https://repo1.maven.org/maven2/org/scala-lang/scala-library/2.12.9/scala-library-2.12.9.jar ...
[info] downloading https://repo1.maven.org/maven2/org/scala-lang/scala-compiler/2.12.9/scala-compiler-2.12.9.jar ...                                                                                                
[info] downloading https://repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.12.9/scala-reflect-2.12.9.jar ...                                                                                                  
[info] downloading https://repo1.maven.org/maven2/org/fusesource/jansi/jansi/1.12/jansi-1.12.jar ...
[info]  [SUCCESSFUL ] org.scala-lang#scala-reflect;2.12.9!scala-reflect.jar (454ms)                                                                                                                                 
[info]  [SUCCESSFUL ] org.fusesource.jansi#jansi;1.12!jansi.jar (446ms)                                   
[info]  [SUCCESSFUL ] org.scala-lang#scala-library;2.12.9!scala-library.jar (1096ms)                      
[info]  [SUCCESSFUL ] org.scala-lang#scala-compiler;2.12.9!scala-compiler.jar (1518ms)
[info] Done updating.                                                                                     
[info] Compiling 1 Scala source to /tmp/tmp.hrfM92SWVI/target/scala-2.12/classes ...
[info] Non-compiled module 'compiler-bridge_2.12' for Scala 2.12.9. Compiling...                                                                                                                                    
[info]   Compilation completed in 8.037s.
```

This adds the necessary steps to already do this in the docker image, so CI doesn't have to do
it every time.

As a smaller step, I also extracted the installation of the tools (bash, jq, ...) into a separate layer